### PR TITLE
[KAN-38] Heading 컴포넌트 구현

### DIFF
--- a/app/hyunwooTest.tsx
+++ b/app/hyunwooTest.tsx
@@ -1,7 +1,6 @@
 import { StyleSheet, Text, View } from "react-native";
 
-import IconButton from "@/components/ui/IconButton";
-import { colors } from "@/constants/colors";
+import Heading from "@/components/ui/Heading";
 
 export default function TestScreen() {
   const handlePressButton = () => {
@@ -10,38 +9,12 @@ export default function TestScreen() {
 
   return (
     <View style={styles.screen}>
-      <Text style={{ fontFamily: "BM", fontWeight: "bold" }}>
-        Hyunwoo Test Screen
-      </Text>
-      <View style={{ flexDirection: "row" }}>
-        <IconButton
-          iconName="back"
-          iconColor={colors.theme.primary}
-          disabled={true}
-          onPress={handlePressButton}
-        />
-        <IconButton
-          iconName="setting"
-          iconColor={colors.theme.primary}
-          onPress={handlePressButton}
-        />
-        <IconButton
-          iconName="more"
-          iconColor={colors.theme.black}
-          onPress={handlePressButton}
-        />
-        <IconButton
-          iconName="send"
-          iconColor={colors.theme.primary}
-          onPress={handlePressButton}
-        />
-        <IconButton
-          type="transparent"
-          iconName="sort"
-          iconColor={colors.theme.black}
-          onPress={handlePressButton}
-        />
-      </View>
+      <Heading level={1}>H1: Hyunwoo Test</Heading>
+      <Heading level={2}>H2: Hyunwoo Test</Heading>
+      <Heading level={3}>H3: Hyunwoo Test</Heading>
+      <Heading level={4}>H4: Hyunwoo Test</Heading>
+      <Heading level={5}>H5: Hyunwoo Test</Heading>
+      <Heading level={6}>H6: Hyunwoo Test</Heading>
     </View>
   );
 }

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,0 +1,52 @@
+// components/Heading.tsx
+import { font } from "@/constants/font";
+import { wScale } from "@/util/responsive.util";
+import React from "react";
+import { Text, StyleSheet, TextProps } from "react-native";
+
+interface HeadingProps extends TextProps {
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  children: React.ReactNode;
+}
+
+export default function Heading({
+  level,
+  children,
+  style,
+  ...props
+}: HeadingProps) {
+  const textStyle = [styles[`h${level}`], style];
+
+  return (
+    <Text style={textStyle} {...props}>
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  h1: {
+    fontSize: wScale(34),
+    fontFamily: font.family.BM,
+  },
+  h2: {
+    fontSize: wScale(28),
+    fontFamily: font.family.BM,
+  },
+  h3: {
+    fontSize: wScale(24),
+    fontFamily: font.family.BM,
+  },
+  h4: {
+    fontSize: wScale(18),
+    fontFamily: font.family.BM,
+  },
+  h5: {
+    fontSize: wScale(16),
+    fontFamily: font.family.BM,
+  },
+  h6: {
+    fontSize: wScale(14),
+    fontFamily: font.family.BM,
+  },
+});

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,24 +1,19 @@
-// components/Heading.tsx
 import { font } from "@/constants/font";
 import { wScale } from "@/util/responsive.util";
 import React from "react";
 import { Text, StyleSheet, TextProps } from "react-native";
 
-interface HeadingProps extends TextProps {
-  level: 1 | 2 | 3 | 4 | 5 | 6;
+type HeadingProps = TextProps & {
   children: React.ReactNode;
-}
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+};
 
-export default function Heading({
-  level,
-  children,
-  style,
-  ...props
-}: HeadingProps) {
-  const textStyle = [styles[`h${level}`], style];
-
+export default function Heading({ children, level, ...props }: HeadingProps) {
   return (
-    <Text style={textStyle} {...props}>
+    <Text
+      style={[styles[`h${level}`], { fontFamily: font.family.BM }]}
+      {...props}
+    >
       {children}
     </Text>
   );
@@ -27,26 +22,20 @@ export default function Heading({
 const styles = StyleSheet.create({
   h1: {
     fontSize: wScale(34),
-    fontFamily: font.family.BM,
   },
   h2: {
     fontSize: wScale(28),
-    fontFamily: font.family.BM,
   },
   h3: {
     fontSize: wScale(24),
-    fontFamily: font.family.BM,
   },
   h4: {
     fontSize: wScale(18),
-    fontFamily: font.family.BM,
   },
   h5: {
     fontSize: wScale(16),
-    fontFamily: font.family.BM,
   },
   h6: {
     fontSize: wScale(14),
-    fontFamily: font.family.BM,
   },
 });


### PR DESCRIPTION
# Pull Request

## 구현 화면

<img width="351" alt="image" src="https://github.com/watermelon-blossom/blossom-FE/assets/55650821/f3e63f51-a1b0-4ba0-905a-978c63535a50">

## 구현 기능

- Heading 컴포넌트를 구현하였습니다. 
- H1부터 H6까지의 범위

## 기타 질문 및 특이 사항

저번에 얘기하셨던 건 H4까지인데 figma에 맞춰서 우선은 H6까지 만들긴 했습니다. 관련해서 의견 부탁드립니다!
추가로 figma에는 H2 크기가 정해져있지 않아서 28로 임시 설정하였습니다!

- (예시) 이용약관 체크박스 기능 구현 로직이 너무 지저분하고 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다!

## PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [x] JIRA Issues에서 적절한 이슈 하나를 연동하였습니다.
- [x] 본 PR을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 기능이 제대로 실행되는지 확인 하였습니다.
- [x] yarn start로 구현한 화면 혹은 기능을 확인할 수 있습니다.
- [x] self-refactoring으로 WaterMelon FE 코딩 컨벤션에 준수하는지 점검하였습니다.

> 마크다운에서 체크를 하기 위해서는 [x] 이렇게 수정하시면 됩니다. [x ], [ x ] 가 아니라 정확하게 [x]여야 합니다. 혹은 마우스 클릭으로 체크해주세요.
