### PR TITLE
[KAN-51] 매치성공 화면

### DIFF
--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -20,12 +20,12 @@ export default function account() {
   return (
     <View style={styles.container}>
       <CText>Account</CText>
-      <Header
+      {/* <Header
         left={<IconButton iconName="back" />}
         right={<IconButton iconName="setting" />}
         title="Account"
         subTitle="Account"
-      />
+      /> */}
     </View>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout() {
   // testpage 자동 이동용
   useEffect(() => {
     if (loaded) {
-      router.navigate("siwonTest");
+      router.navigate("matchSuccess");
     }
   }, [loaded]);
 
@@ -45,6 +45,7 @@ export default function RootLayout() {
           >
             <Stack.Screen name="(tabs)" />
             <Stack.Screen name="index" />
+            <Stack.Screen name="matchSuccess" />
             <Stack.Screen name="hyunwooTest" />
             <Stack.Screen name="siwonTest" options={{ headerShown: false }} />
             <Stack.Screen name="+not-found" />

--- a/app/matchSuccess.tsx
+++ b/app/matchSuccess.tsx
@@ -1,0 +1,99 @@
+import { router } from "expo-router";
+import { StyleSheet, View } from "react-native";
+
+import Button from "@/components/ui/Button";
+import CText from "@/components/ui/CText";
+import Heading from "@/components/ui/Heading";
+import MatchedCard from "@/components/ui/MatchedCard";
+
+import { theme } from "@/constants/colors";
+import { wScale } from "@/util/responsive.util";
+
+const leftUri =
+  "https://sports.hankooki.com/news/photo/202111/img_6748965_0.jpg";
+const rightUri =
+  "https://www.breaknews.com/imgdata/breaknews_com/202209/2022090545135162.jpg";
+
+export default function matchSuccess() {
+  const hadlePressChat = () => {
+    router.navigate("/messages");
+  };
+
+  const handlePressContinue = () => {
+    router.navigate("/discover");
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.imgWrapper}>
+        <MatchedCard style={styles.rightPosition} uri={rightUri} side="right" />
+        <MatchedCard style={styles.leftPosition} uri={leftUri} />
+      </View>
+
+      <View style={styles.textWrapper}>
+        <Heading style={styles.titleText} level={1}>
+          매칭 성공!
+        </Heading>
+        <CText>먼저 상대방에게 말을 걸어보세요!</CText>
+      </View>
+
+      <View style={styles.buttonWrapper}>
+        <Button type="primary" onPress={hadlePressChat}>
+          인사 건네기
+        </Button>
+        <Button
+          style={styles.subButton}
+          textStyle={styles.subButtonText}
+          onPress={handlePressContinue}
+        >
+          디스커버 이어서 하기
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: "100%",
+    alignItems: "center",
+    padding: wScale(40),
+  },
+  imgWrapper: {
+    flex: 3,
+  },
+  leftPosition: {
+    position: "absolute",
+    left: wScale(-130),
+    top: wScale(120),
+  },
+  rightPosition: {
+    position: "absolute",
+    right: wScale(-120),
+    top: wScale(20),
+  },
+  textWrapper: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: wScale(16),
+  },
+  titleText: {
+    color: theme.primary,
+  },
+  buttonWrapper: {
+    flex: 1,
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: wScale(16),
+  },
+  subButton: {
+    backgroundColor: "#fdecee",
+    borderWidth: 0,
+  },
+  subButtonText: {
+    color: theme.primary,
+  },
+});

--- a/app/siwonTest.tsx
+++ b/app/siwonTest.tsx
@@ -7,6 +7,7 @@ import { theme } from "@/constants/colors";
 import QCarousel, { QCarouselDataProp } from "@/components/ui/QCarousel";
 import { ICarouselInstance } from "react-native-reanimated-carousel";
 import ActionButton from "@/components/ui/ActionButton";
+import MatchedCard from "@/components/ui/MatchedCard";
 
 // const DATA: QCarouselDataProp = [
 //   require("../assets/images/test1.png"),
@@ -24,14 +25,9 @@ export default function TestScreen() {
   return (
     <>
       <View style={styles.screen}>
-        <ActionButton type="REJECT" onPress={hadlePress} />
-        <ActionButton type="MATCH" onPress={hadlePress} />
-        <ActionButton type="SUPERLIKE" onPress={hadlePress} />
-      </View>
-      <View style={styles.screen}>
-        <ActionButton type="REJECT" disabled onPress={hadlePress} />
-        <ActionButton type="MATCH" disabled onPress={hadlePress} />
-        <ActionButton type="SUPERLIKE" disabled onPress={hadlePress} />
+        {/* <ActionButton type="REJECT" onPress={hadlePress} /> */}
+        {/* <ActionButton type="MATCH" onPress={hadlePress} /> */}
+        {/* <ActionButton type="SUPERLIKE" onPress={hadlePress} /> */}
       </View>
     </>
   );

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,4 +1,11 @@
-import { Pressable, PressableProps, StyleSheet, Text } from "react-native";
+import {
+  Pressable,
+  PressableProps,
+  StyleSheet,
+  Text,
+  TextStyle,
+  ViewStyle,
+} from "react-native";
 import { font } from "@/constants/font";
 import { colors } from "@/constants/colors";
 import { wScale } from "@/util/responsive.util";
@@ -11,6 +18,8 @@ type ButtonProps = PressableProps & {
   isHasShadow?: boolean;
   width?: string | number;
   height?: string | number;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
   onPress?: () => void;
 };
 
@@ -22,6 +31,8 @@ export default function Button({
   isHasShadow = false,
   width = "80%",
   height = wScale(58),
+  style,
+  textStyle,
   onPress,
   ...props
 }: ButtonProps) {
@@ -32,6 +43,7 @@ export default function Button({
         type === "primary" && typeStyles.primaryBg,
         type === "outline" && typeStyles.outlineBg,
         { width: width as any, height: height as any },
+        style,
         disabled && styles.disabledStyle,
         isHasShadow && layoutStyles.shadow,
         !disabled && pressed && styles.pressed,
@@ -45,6 +57,7 @@ export default function Button({
             type === "primary" && typeStyles.primaryText,
             type === "outline" && typeStyles.outlineText,
             sizeStyles[size],
+            textStyle,
             disabled && { color: colors.theme.white },
           ]}
         >

--- a/components/ui/Heading.tsx
+++ b/components/ui/Heading.tsx
@@ -1,17 +1,23 @@
 import { font } from "@/constants/font";
 import { wScale } from "@/util/responsive.util";
 import React from "react";
-import { Text, StyleSheet, TextProps } from "react-native";
+import { Text, StyleSheet, TextProps, TextStyle } from "react-native";
 
 type HeadingProps = TextProps & {
   children: React.ReactNode;
   level: 1 | 2 | 3 | 4 | 5 | 6;
+  style?: TextStyle;
 };
 
-export default function Heading({ children, level, ...props }: HeadingProps) {
+export default function Heading({
+  children,
+  level,
+  style,
+  ...props
+}: HeadingProps) {
   return (
     <Text
-      style={[styles[`h${level}`], { fontFamily: font.family.BM }]}
+      style={[styles[`h${level}`], { fontFamily: font.family.BM }, style]}
       {...props}
     >
       {children}

--- a/components/ui/MatchedCard.tsx
+++ b/components/ui/MatchedCard.tsx
@@ -1,0 +1,95 @@
+import { StyleSheet, View, ViewStyle } from "react-native";
+import SvgIcon from "./SvgIcon";
+import { wScale } from "@/util/responsive.util";
+import { Image } from "expo-image";
+import { colors, theme } from "@/constants/colors";
+
+type MatchedCardProps = {
+  uri: string;
+  side?: "left" | "right";
+  style?: ViewStyle;
+};
+
+export default function MatchedCard({
+  uri,
+  side = "left",
+  style,
+}: MatchedCardProps) {
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          transform: [
+            {
+              rotateZ: side === "left" ? "-10deg" : "10deg",
+            },
+          ],
+        },
+        style,
+      ]}
+    >
+      <Image
+        style={styles.img}
+        source={{ uri }}
+        contentFit="cover"
+        transition={1000}
+      />
+      <View
+        style={[
+          styles.circle,
+          side === "left"
+            ? {
+                left: wScale(-15),
+                bottom: wScale(-15),
+              }
+            : {
+                left: wScale(-15),
+                top: wScale(-15),
+              },
+        ]}
+      >
+        <SvgIcon name="like" size={wScale(30)} fill="#E94057" />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: wScale(160),
+    height: wScale(240),
+    borderRadius: wScale(20),
+    backgroundColor: theme.white,
+    shadowColor: "#000",
+    shadowOffset: {
+      width: wScale(10),
+      height: wScale(10),
+    },
+    shadowOpacity: 0.2,
+    shadowRadius: wScale(10),
+    elevation: wScale(10),
+  },
+  img: {
+    width: "100%",
+    height: "100%",
+    borderRadius: wScale(20),
+  },
+  circle: {
+    position: "absolute",
+    width: wScale(50),
+    height: wScale(50),
+    borderRadius: wScale(50),
+    backgroundColor: theme.white,
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: wScale(2),
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: wScale(3.84),
+    elevation: wScale(5),
+  },
+});

--- a/components/ui/MatchedCard.tsx
+++ b/components/ui/MatchedCard.tsx
@@ -49,7 +49,7 @@ export default function MatchedCard({
               },
         ]}
       >
-        <SvgIcon name="like" size={wScale(30)} fill="#E94057" />
+        <SvgIcon name="like" size={wScale(30)} fill={theme.primary} />
       </View>
     </View>
   );

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo": "~51.0.8",
     "expo-constants": "~16.0.1",
     "expo-font": "~12.0.5",
+    "expo-image": "~1.12.12",
     "expo-image-picker": "^15.0.5",
     "expo-linking": "~6.3.1",
     "expo-router": "~3.5.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,6 +3962,11 @@ expo-image-picker@^15.0.5:
   dependencies:
     expo-image-loader "~4.7.0"
 
+expo-image@~1.12.12:
+  version "1.12.12"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-1.12.12.tgz#b6422a07da0f6dddcea154d2857f617086a527cc"
+  integrity sha512-zZutUhKYqcqTH12o87pGCVLsuQeRK2vaNwxa8beznbDnmWevm3dmbOTCxaOhGgjyDxwcdwDa483Q4IKCXL6tBw==
+
 expo-keep-awake@~13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz#5ef31311a339671eec9921b934fdd90ab9652b0e"
@@ -7813,16 +7818,7 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7882,7 +7878,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7895,13 +7891,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -8663,7 +8652,7 @@ wonka@^6.3.2:
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.4.tgz#76eb9316e3d67d7febf4945202b5bdb2db534594"
   integrity sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8676,15 +8665,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Pull Request

## 구현 화면

![스크린샷 2024-07-02 오후 10 34 30](https://github.com/watermelon-blossom/blossom-FE/assets/39205612/9771973e-0a84-4011-93d0-585502fb8544)

- 구현화면의 스크린샷 혹은 gif 파일을 함께 업로드 해주세요.

## 구현 기능

- 매치 성공화면 구현
- MatchedCard 컴포넌트 구현
- Button, Heading 스타일 부여 가능하도록 수정

## 기타 질문 및 특이 사항

- Button, Heading에 스타일 수정가능하도록 프롭스 열어두는 수정 하였습니다! 확인해주세요!

## PR을 올렸다면 아래 사항은 반드시 지켜주세요.

- [x] JIRA Issues에서 적절한 이슈 하나를 연동하였습니다.
- [x] 본 PR을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 기능이 제대로 실행되는지 확인 하였습니다.
- [x] yarn start로 구현한 화면 혹은 기능을 확인할 수 있습니다.
- [x] self-refactoring으로 WaterMelon FE 코딩 컨벤션에 준수하는지 점검하였습니다.

> 마크다운에서 체크를 하기 위해서는 [x] 이렇게 수정하시면 됩니다. [x ], [ x ] 가 아니라 정확하게 [x]여야 합니다. 혹은 마우스 클릭으로 체크해주세요.
