### PR TITLE
[bugfix] git 대소문자 구분으로 인한 오류 수정

### DIFF
--- a/assets/icons/index.ts
+++ b/assets/icons/index.ts
@@ -14,3 +14,4 @@ export { default as setting } from "./setting.svg";
 export { default as slideHandle } from "./slide_handle.svg";
 export { default as sort } from "./sort.svg";
 export { default as star } from "./star.svg";
+export { default as right } from "./right.svg";


### PR DESCRIPTION
# Pull Request

git 대소문자 구분설정으로 인해서 icons, Icons 폴더가 동시에 소스에 올라가버렸습니다. 
로컬에서는 수정했는데 리모트에 반영이 되는지 확인을 해보아야할것 같습니다.
이거 머지해보고 안되면 깃헙상에서 Icons 폴더를 삭제해야할것 같습니다.
지라 티켓 생성하기 애매해서 임시로 bugfix로 브랜치 만들어서 pr 올렸습니다.